### PR TITLE
Rename rank 4 Scrounger perk

### DIFF
--- a/fo4/js/perks.js
+++ b/fo4/js/perks.js
@@ -1599,7 +1599,7 @@
                     {
                         rank: 4,
                         level: 37,
-                        description: 'You find even more ammunition in containers.'
+                        description: 'There is a chance to gain ammo when firing the last round in your clip.'
                     }
                 ]
             },


### PR DESCRIPTION
Scrounger perk rank 4 was named "You find even more ammunition in containers." same as rank 3 and 2, but the correct one is "There is a chance to gain ammo when firing the last round in your clip."

If wanna check https://fallout.fandom.com/wiki/Scrounger_(Fallout_4) 
